### PR TITLE
Fix CSV size on export

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,8 @@ services:
       - ELASTICSEARCH_URL=http://elasticsearch:9200
     depends_on:
       - elasticsearch
-
+    volumes:
+      - ./kibana/kibana.yml:/usr/share/kibana/config/kibana.yml
   web:
     build: .
     volumes:

--- a/kibana/kibana.yml
+++ b/kibana/kibana.yml
@@ -1,0 +1,6 @@
+# Default Kibana configuration for docker target
+server.name: kibana
+server.host: "0"
+elasticsearch.hosts: [ "http://elasticsearch:9200" ]
+xpack.monitoring.ui.container.elasticsearch.enabled: true
+xpack.reporting.csv.maxSizeBytes: 2048576000


### PR DESCRIPTION
A equipe de saúde requisitou que os CSV contenham todos os dados de surveys. Como o servidor tem uma configuração que limita os dados de um CSV para 10mb e os surveys tem mais, para atender esta demanda, aleterei o limite de dados para 2gb.