### PR TITLE
Fixing error that does not show name of the symptoms

### DIFF
--- a/src/pages/Home/components/Syndromes/index.js
+++ b/src/pages/Home/components/Syndromes/index.js
@@ -312,8 +312,9 @@ const Syndromes = ({
                     </EditInput>
 
                     {syndromeShow.symptoms ? syndromeShow.symptoms.map(symptom => (
+                    <>
                         <EditInput className="bg-light p-2">
-                            <h6>{symptom.label}</h6>
+                            <h6>{symptom.description}</h6>
                             <label htmlFor={`percentage-${symptom.id}`}>Porcentagem</label>
                             <input
                                 type="number"
@@ -324,7 +325,9 @@ const Syndromes = ({
                                 value={symptom.percentage}
                                 disabled
                             />
+                            <h6>{symptom.label}</h6>
                         </EditInput>
+                    </>
                     )) : null }
                 </Modal.Body>
 


### PR DESCRIPTION
This PR fixes the show syndrome modal. The error is better explained in issue #134. To fix i just changed the name of the attribute of the symptom from "label" to "description", that is the actual attribute name returned from api.
![Captura de tela de 2020-11-16 16-27-34](https://user-images.githubusercontent.com/31369018/99298886-31d8e400-2829-11eb-912c-dd34795e6037.png)
