### PR TITLE
Percentage in syndrom page is fixed

### DIFF
--- a/src/pages/Home/components/Syndromes/index.js
+++ b/src/pages/Home/components/Syndromes/index.js
@@ -213,10 +213,10 @@ const Syndromes = ({
                                     type="number"
                                     id={`edit_percentage-${s.value}`}
                                     min={0}
-                                    max={1}
-                                    step={0.01}
-                                    value={s.percentage}
-                                    onChange={(e) => handleEditPercentage(e.target.value, s)}
+                                    max={100}
+                                    step={1}
+                                    value={s.percentage * 100}
+                                    onChange={(e) => handleEditPercentage(e.target.value/100, s)}
                                 />
                             </EditInput>
                         ))}                        


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/10068425/99619748-e2e6a680-2a02-11eb-8b5e-620e1cb105c9.png)


Não consegui fazer aparecer o símbolo de porcentagem na tela correta, mas ajustei os valores na tela para irem de 0 a 100, ao invés de decimais.