### PR TITLE
Add metabase dashboard

### DIFF
--- a/src/pages/Home/components/Dashboard/index.js
+++ b/src/pages/Home/components/Dashboard/index.js
@@ -47,7 +47,7 @@ function Dashboard(props) {
           <a className={`nav-link ${isCurrentNav('dados') ? 'active' : ''}`} href="#dados">Tabelas de dados</a>
         </li>
         <li className="nav-item">
-          <a className={`nav-link ${isCurrentNav('metabase') ? 'active' : ''}`} href="#metabase">Metabase</a>
+          <a className={`nav-link ${isCurrentNav('dashboard') ? 'active' : ''}`} href="#dashboard">Dashboard</a>
         </li>
       </ul>
 
@@ -81,7 +81,7 @@ function Dashboard(props) {
         />
       </div>
 
-      <div className={`dash visualizations ${isCurrentNav('metabase') ? '' : 'd-none'}`}>
+      <div className={`dash visualizations ${isCurrentNav('dashboard') ? '' : 'd-none'}`}>
         <div style={{ display: 'flex', justifyContent: 'space-around', flexWrap: 'wrap' }}>
           {urls.length && urls.map((url) => {
             return (

--- a/src/pages/Home/components/Dashboard/index.js
+++ b/src/pages/Home/components/Dashboard/index.js
@@ -15,8 +15,6 @@ function Dashboard(props) {
     setUrls(response.urls)
   }
 
-  const links = ["http://localhost:3002/embed/question/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZXNvdXJjZSI6eyJxdWVzdGlvbiI6MTB9LCJwYXJhbXMiOnt9LCJleHAiOjE2MDcxMjY1NzMsImlhdCI6MTYwNzEyNTk3Mn0.6bK1VRHV1wTOxhF6OLMSskO5Q_wsPTW3FqZvazekYeU#bordered=true&titled=true"]
-
   useEffect(() => {
     _getUrls()
     if (isEmpty(hashes)) {

--- a/src/pages/Home/components/Dashboard/index.js
+++ b/src/pages/Home/components/Dashboard/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import getGraphs from './services/getGraphs'
 import queryString from 'query-string';
 import { isEmpty } from "lodash";
 import './styles.css';
@@ -6,6 +7,16 @@ import './styles.css';
 function Dashboard(props) {
   const [currentNav, setCurrentNav] = useState({})
   const hashes = queryString.parse(window.location.hash)
+
+  // const data = [];
+
+  // const graphs = await getGraphs(token, data); 
+
+  const graphs = ['http://localhost:3002/public/question/e287c23c-9ea0-4b22-bff9-dd3980055f4d',
+    'http://localhost:3002/public/question/8752d781-37e0-4555-812b-031667995933',
+    'http://localhost:3002/public/question/e287c23c-9ea0-4b22-bff9-dd3980055f4d',
+    'http://localhost:3002/public/question/e287c23c-9ea0-4b22-bff9-dd3980055f4d'
+  ]
 
   useEffect(() => {
     if (isEmpty(hashes)) {
@@ -35,6 +46,9 @@ function Dashboard(props) {
         </li>
         <li className="nav-item">
           <a className={`nav-link ${isCurrentNav('dados') ? 'active' : ''}`} href="#dados">Tabelas de dados</a>
+        </li>
+        <li className="nav-item">
+          <a className={`nav-link ${isCurrentNav('metabase') ? 'active' : ''}`} href="#metabase">Metabase</a>
         </li>
       </ul>
 
@@ -66,6 +80,24 @@ function Dashboard(props) {
           height="1250"
           width="100%"
         />
+      </div>
+
+      <div className={`dash visualizations ${isCurrentNav('metabase') ? '' : 'd-none'}`}>
+        <div style={{display:'flex', justifyContent:'space-around', flexWrap:'wrap'}}>
+          {graphs.map((url) => {
+            return (
+              <div style={{ margin: 10 }}>
+                <iframe
+                  src={url}
+                  frameborder="0"
+                  width="600"
+                  height="400"
+                  allowtransparency
+                />
+              </div>
+            )
+          })}
+        </div>
       </div>
 
       <i className={"note"}>NOTA: caso você encontre problemas nessa página, use o navegador Firefox</i>

--- a/src/pages/Home/components/Dashboard/index.js
+++ b/src/pages/Home/components/Dashboard/index.js
@@ -6,19 +6,19 @@ import './styles.css';
 
 function Dashboard(props) {
   const [currentNav, setCurrentNav] = useState({})
+  const [urls, setUrls] = useState({})
   const hashes = queryString.parse(window.location.hash)
 
-  // const data = [];
+  const _getUrls = async () => {
+    const response = await getGraphs()
+    // console.log(response)
+    setUrls(response.urls)
+  }
 
-  // const graphs = await getGraphs(token, data); 
-
-  const graphs = ['http://localhost:3002/public/question/e287c23c-9ea0-4b22-bff9-dd3980055f4d',
-    'http://localhost:3002/public/question/8752d781-37e0-4555-812b-031667995933',
-    'http://localhost:3002/public/question/e287c23c-9ea0-4b22-bff9-dd3980055f4d',
-    'http://localhost:3002/public/question/e287c23c-9ea0-4b22-bff9-dd3980055f4d'
-  ]
+  const links = ["http://localhost:3002/embed/question/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZXNvdXJjZSI6eyJxdWVzdGlvbiI6MTB9LCJwYXJhbXMiOnt9LCJleHAiOjE2MDcxMjY1NzMsImlhdCI6MTYwNzEyNTk3Mn0.6bK1VRHV1wTOxhF6OLMSskO5Q_wsPTW3FqZvazekYeU#bordered=true&titled=true"]
 
   useEffect(() => {
+    _getUrls()
     if (isEmpty(hashes)) {
       setCurrentNav({ geral: null })
     }
@@ -26,18 +26,19 @@ function Dashboard(props) {
       setCurrentNav(hashes)
     }
   }, [hashes.geral, hashes.adesao, hashes.dados]);
-
+  
   const isCurrentNav = (string) => {
     if (typeof currentNav[string] !== "undefined") return true
     return false
   }
-
   // This allows a begin date for iframes
   let date = props.date || '2020-06-10T07:01:16.923Z' // App launch date
 
+  console.log(urls)
+
   return (
     <div className="dash visualizations">
-      <ul className="nav nav-tabs justify-content-center" style={{marginTop: 20}}>
+      <ul className="nav nav-tabs justify-content-center" style={{ marginTop: 20 }}>
         <li className="nav-item">
           <a className={`nav-link ${isCurrentNav('geral') ? 'active' : ''}`} href="#geral">Dados gerais</a>
         </li>
@@ -65,9 +66,9 @@ function Dashboard(props) {
       <div className={`dash visualizations ${isCurrentNav('adesao') ? '' : 'd-none'}`}>
         <iframe
           title="Dados sobre adesão"
-          src={"http://painel.gds.proepi.org.br:5601/app/kibana#/dashboard/890db060-c06f-11ea-8757-c560579e51be?embed=true&_g=(refreshInterval:(pause:!t,value:0),time:(from:'" + date + "',to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),panels:!((embeddableConfig:(),gridData:(h:15,i:'19ab77de-4c86-48ae-8bc5-409052991902',w:48,x:0,y:0),id:'000abcf0-e256-11ea-b06d-f32b0ae9e5ff',panelIndex:'19ab77de-4c86-48ae-8bc5-409052991902',type:visualization,version:'7.6.1'),(embeddableConfig:(),gridData:(h:15,i:d4a06aab-f9a2-436e-b8a6-cefa3b711dab,w:48,x:0,y:15),id:'517cf530-e256-11ea-b06d-f32b0ae9e5ff',panelIndex:d4a06aab-f9a2-436e-b8a6-cefa3b711dab,type:visualization,version:'7.6.1'),(embeddableConfig:(),gridData:(h:15,i:'38264330-a718-49f2-9636-dda67d9f719b',w:48,x:0,y:30),id:'54fc7570-e24a-11ea-b06d-f32b0ae9e5ff',panelIndex:'38264330-a718-49f2-9636-dda67d9f719b',type:visualization,version:'7.6.1'),(embeddableConfig:(),gridData:(h:18,i:'269f3c4c-1ea7-4d6d-a3ae-6bfba2982984',w:48,x:0,y:45),id:'2a37dea0-e25a-11ea-b06d-f32b0ae9e5ff',panelIndex:'269f3c4c-1ea7-4d6d-a3ae-6bfba2982984',type:visualization,version:'7.6.1'),(embeddableConfig:(),gridData:(h:15,i:'87eea98b-a107-468c-aeea-f06b096be024',w:48,x:0,y:63),id:a5c35f40-e25a-11ea-b06d-f32b0ae9e5ff,panelIndex:'87eea98b-a107-468c-aeea-f06b096be024',type:visualization,version:'7.6.1'),(embeddableConfig:(hiddenLayers:!(),isLayerTOCOpen:!f,mapCenter:(lat:-14.14736,lon:-52.64071,zoom:3.6),openTOCDetails:!()),gridData:(h:30,i:fcc41562-98bd-411c-8995-d9ceaf3352af,w:48,x:0,y:93),id:ce21ad90-c0a2-11ea-8757-c560579e51be,panelIndex:fcc41562-98bd-411c-8995-d9ceaf3352af,type:map,version:'7.6.1'),(embeddableConfig:(),gridData:(h:15,i:'2cc1390c-8d30-4712-ba41-d6cf01242fc6',w:48,x:0,y:78),id:'47a719e0-e261-11ea-b06d-f32b0ae9e5ff',panelIndex:'2cc1390c-8d30-4712-ba41-d6cf01242fc6',type:visualization,version:'7.6.1')),query:(language:kuery,query:''),timeRestore:!t,title:'M%C3%A9tricas%20de%20engajamento%20-%20Guardi%C3%B5es%20da%20Sa%C3%BAde',viewMode:view)"} 
+          src={"http://painel.gds.proepi.org.br:5601/app/kibana#/dashboard/890db060-c06f-11ea-8757-c560579e51be?embed=true&_g=(refreshInterval:(pause:!t,value:0),time:(from:'" + date + "',to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),panels:!((embeddableConfig:(),gridData:(h:15,i:'19ab77de-4c86-48ae-8bc5-409052991902',w:48,x:0,y:0),id:'000abcf0-e256-11ea-b06d-f32b0ae9e5ff',panelIndex:'19ab77de-4c86-48ae-8bc5-409052991902',type:visualization,version:'7.6.1'),(embeddableConfig:(),gridData:(h:15,i:d4a06aab-f9a2-436e-b8a6-cefa3b711dab,w:48,x:0,y:15),id:'517cf530-e256-11ea-b06d-f32b0ae9e5ff',panelIndex:d4a06aab-f9a2-436e-b8a6-cefa3b711dab,type:visualization,version:'7.6.1'),(embeddableConfig:(),gridData:(h:15,i:'38264330-a718-49f2-9636-dda67d9f719b',w:48,x:0,y:30),id:'54fc7570-e24a-11ea-b06d-f32b0ae9e5ff',panelIndex:'38264330-a718-49f2-9636-dda67d9f719b',type:visualization,version:'7.6.1'),(embeddableConfig:(),gridData:(h:18,i:'269f3c4c-1ea7-4d6d-a3ae-6bfba2982984',w:48,x:0,y:45),id:'2a37dea0-e25a-11ea-b06d-f32b0ae9e5ff',panelIndex:'269f3c4c-1ea7-4d6d-a3ae-6bfba2982984',type:visualization,version:'7.6.1'),(embeddableConfig:(),gridData:(h:15,i:'87eea98b-a107-468c-aeea-f06b096be024',w:48,x:0,y:63),id:a5c35f40-e25a-11ea-b06d-f32b0ae9e5ff,panelIndex:'87eea98b-a107-468c-aeea-f06b096be024',type:visualization,version:'7.6.1'),(embeddableConfig:(hiddenLayers:!(),isLayerTOCOpen:!f,mapCenter:(lat:-14.14736,lon:-52.64071,zoom:3.6),openTOCDetails:!()),gridData:(h:30,i:fcc41562-98bd-411c-8995-d9ceaf3352af,w:48,x:0,y:93),id:ce21ad90-c0a2-11ea-8757-c560579e51be,panelIndex:fcc41562-98bd-411c-8995-d9ceaf3352af,type:map,version:'7.6.1'),(embeddableConfig:(),gridData:(h:15,i:'2cc1390c-8d30-4712-ba41-d6cf01242fc6',w:48,x:0,y:78),id:'47a719e0-e261-11ea-b06d-f32b0ae9e5ff',panelIndex:'2cc1390c-8d30-4712-ba41-d6cf01242fc6',type:visualization,version:'7.6.1')),query:(language:kuery,query:''),timeRestore:!t,title:'M%C3%A9tricas%20de%20engajamento%20-%20Guardi%C3%B5es%20da%20Sa%C3%BAde',viewMode:view)"}
           frameBorder="0"
-          height="3550" 
+          height="3550"
           width="100%"
         />
       </div>
@@ -75,7 +76,7 @@ function Dashboard(props) {
       <div className={`dash visualizations ${isCurrentNav('dados') ? '' : 'd-none'}`}>
         <iframe
           title="Tabelas de dados"
-          src={"http://painel.gds.proepi.org.br:5601/app/kibana#/dashboard/926885c0-acd0-11ea-8757-c560579e51be?embed=true&_g=(refreshInterval:(pause:!t,value:0),time:(from:'" + date + "',to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),panels:!((embeddableConfig:(),gridData:(h:3,i:ea5f3762-c339-47d1-bc92-9ef6346cf66e,w:48,x:0,y:0),id:b18405e0-ace1-11ea-8757-c560579e51be,panelIndex:ea5f3762-c339-47d1-bc92-9ef6346cf66e,type:visualization,version:'7.6.1'),(embeddableConfig:(),gridData:(h:20,i:'492b704d-1fee-4fae-aab1-3c13d668136a',w:48,x:0,y:3),id:'231e3e70-ed2c-11ea-a5d0-b9c877143e8b',panelIndex:'492b704d-1fee-4fae-aab1-3c13d668136a',type:search,version:'7.6.1'),(embeddableConfig:(),gridData:(h:19,i:f589cd8e-bafd-4b39-aece-18a90f8afbdd,w:48,x:0,y:23),id:bd3b53e0-ed2b-11ea-a5d0-b9c877143e8b,panelIndex:f589cd8e-bafd-4b39-aece-18a90f8afbdd,type:search,version:'7.6.1')),query:(language:kuery,query:''),timeRestore:!f,title:Relat%C3%B3rios,viewMode:view)"} 
+          src={"http://painel.gds.proepi.org.br:5601/app/kibana#/dashboard/926885c0-acd0-11ea-8757-c560579e51be?embed=true&_g=(refreshInterval:(pause:!t,value:0),time:(from:'" + date + "',to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),panels:!((embeddableConfig:(),gridData:(h:3,i:ea5f3762-c339-47d1-bc92-9ef6346cf66e,w:48,x:0,y:0),id:b18405e0-ace1-11ea-8757-c560579e51be,panelIndex:ea5f3762-c339-47d1-bc92-9ef6346cf66e,type:visualization,version:'7.6.1'),(embeddableConfig:(),gridData:(h:20,i:'492b704d-1fee-4fae-aab1-3c13d668136a',w:48,x:0,y:3),id:'231e3e70-ed2c-11ea-a5d0-b9c877143e8b',panelIndex:'492b704d-1fee-4fae-aab1-3c13d668136a',type:search,version:'7.6.1'),(embeddableConfig:(),gridData:(h:19,i:f589cd8e-bafd-4b39-aece-18a90f8afbdd,w:48,x:0,y:23),id:bd3b53e0-ed2b-11ea-a5d0-b9c877143e8b,panelIndex:f589cd8e-bafd-4b39-aece-18a90f8afbdd,type:search,version:'7.6.1')),query:(language:kuery,query:''),timeRestore:!f,title:Relat%C3%B3rios,viewMode:view)"}
           frameBorder="0"
           height="1250"
           width="100%"
@@ -83,12 +84,12 @@ function Dashboard(props) {
       </div>
 
       <div className={`dash visualizations ${isCurrentNav('metabase') ? '' : 'd-none'}`}>
-        <div style={{display:'flex', justifyContent:'space-around', flexWrap:'wrap'}}>
-          {graphs.map((url) => {
+        <div style={{ display: 'flex', justifyContent: 'space-around', flexWrap: 'wrap' }}>
+          {urls.length && urls.map((url) => {
             return (
               <div style={{ margin: 10 }}>
                 <iframe
-                  src={url}
+                  src={url['iframe_url']}
                   frameborder="0"
                   width="600"
                   height="400"

--- a/src/pages/Home/components/Dashboard/services/getGraphs.js
+++ b/src/pages/Home/components/Dashboard/services/getGraphs.js
@@ -1,11 +1,10 @@
 import api from 'services/api';
+import payloads from './payloads';
 
-const getGraphs = async (data, token) => api
-  .post(`/dashboard/auth`, data, 
+const getGraphs = async () => api
+  .post(`/data_visualization/metabase_urls`, 
   {
-    headers: {
-      "Authorization": token,
-    },
+    "payloads": payloads
   }
   )
   .then(async (res) => {

--- a/src/pages/Home/components/Dashboard/services/getGraphs.js
+++ b/src/pages/Home/components/Dashboard/services/getGraphs.js
@@ -1,0 +1,23 @@
+import api from 'services/api';
+
+const getGraphs = async (data, token) => api
+  .post(`/dashboard/auth`, data, 
+  {
+    headers: {
+      "Authorization": token,
+    },
+  }
+  )
+  .then(async (res) => {
+    const { data } = res;
+    return data
+  })
+  .catch((e) => {
+    if (e.response.data.error === "You are not authorized to access this page.") {
+      alert("Você não tem permissão para visualizar Instituições.");
+    }
+    console.log(e);
+    return { data: {}, errors: e }
+  });
+
+export default getGraphs;

--- a/src/pages/Home/components/Dashboard/services/payloads.js
+++ b/src/pages/Home/components/Dashboard/services/payloads.js
@@ -1,0 +1,16 @@
+const payloads = [
+  {
+    "resource": {
+      "question": 10
+    },
+    "params": {}
+  },
+  {
+    "resource": {
+      "question": 11
+    },
+    "params": {}
+  },
+]
+
+export default payloads;


### PR DESCRIPTION
Esse PR faz a integração com api para mostrar os gráficos gerados pelo metabase.

Para adicionar novos gráficos, basta cria-lós no metabase e adicionar os payloads no arquivo "Dashboard/services/payloads.js".

O payload segue o formato: 
~~~javascript
"payloads": [{
     "resource": { "question": <question_id>}, 
     "params": { <params> }  // opcional
   }
]"
~~~

[Guia do metabase](https://www.metabase.com/docs/latest/administration-guide/13-embedding.html) para configurar e pegar os dados dos payloads. 

Para que as alterações funcionem corretamente, é necessário as alterações na api do [PR](https://github.com/proepidesenvolvimento/guardioes-api/pull/202).

Na Issue #124 contem mais informações sobre a integração e o metabase. Como informação complementar, tem o os comentários do [PR](https://github.com/proepidesenvolvimento/guardioes-api/pull/202) do endpoint. 

![Captura de tela de 2020-12-06 18-44-57](https://user-images.githubusercontent.com/37592481/101294002-4c342b00-37f3-11eb-8899-8b196ce70583.png)