### PR TITLE
Campo para atualizar o título do código de identificação

### DIFF
--- a/src/pages/Home/components/GroupManagers/index.js
+++ b/src/pages/Home/components/GroupManagers/index.js
@@ -311,6 +311,16 @@ const GroupManagers = ({
               disabled
             />
           </EditInput>
+
+          <EditInput>
+            <label>Nome do código de identificação</label>
+            <input
+              className="text-dark"
+              type="text"
+              value={groupManagerShow.require_id}
+              disabled
+            />
+          </EditInput>
         </Modal.Body>
 
         <Modal.Footer>

--- a/src/pages/Home/components/GroupManagers/index.js
+++ b/src/pages/Home/components/GroupManagers/index.js
@@ -60,7 +60,8 @@ const GroupManagers = ({
   const [editEmail, setEditEmail] = useState("");
   const [editTwitter, setEditTwitter] = useState("");
   const [editGroup, setEditGroup] = useState("");
-  const [editIDCode, setEditIDCode] = useState(false);
+  const [editIDCode, setEditIDCode] = useState(null);
+  const [editHasIDCode, setEditHasIDCode] = useState(false);
   const [editLengthIDCode, setEditLengthIDCode] = useState(1);
   const [groupManagerShow, setGroupManagerShow] = useState({});
   const [groupManagerLocale, setGroupManagerLocale] = useState(0)
@@ -124,8 +125,8 @@ const GroupManagers = ({
         "email": editEmail,
         "group_name": editGroup,
         "twitter": editTwitter,
-        "require_id": editIDCode,
-        "id_code_length": editIDCode ? editLengthIDCode : null,
+        "require_id": editHasIDCode? editIDCode : null,
+        "id_code_length": editHasIDCode ? editLengthIDCode : null,
         "app_id": user.app_id,
       }
     }
@@ -146,6 +147,7 @@ const GroupManagers = ({
     setEditGroup(content.group_name);
     setEditTwitter(content.twitter);
     setEditIDCode(content.require_id);
+    setEditHasIDCode(content.require_id !== null)
     setEditLengthIDCode(content.id_code_length);
     setModalEdit(!modalEdit);
   }
@@ -168,6 +170,10 @@ const GroupManagers = ({
 
   const handleEditIDCode = (value) => {
     setEditIDCode(value);
+  }
+
+  const handleEditHasIDCode = (value) => {
+    setEditHasIDCode(value);
   }
 
   const handleEditLengthIDCode = (value) => {
@@ -366,16 +372,16 @@ const GroupManagers = ({
             </EditInput>
 
             <EditCheckbox>
-              <label htmlFor="edit_id_code">Código de Identificação</label>
+              <label htmlFor="edit_has_id_code">Código de Identificação</label>
               <EditCheckboxInput
                 type="checkbox"
-                id="edit_id_code"
-                checked={editIDCode}
-                onChange={() => handleEditIDCode(!editIDCode)}
+                id="edit_has_id_code"
+                checked={editHasIDCode}
+                onChange={() => handleEditHasIDCode(!editHasIDCode)}
               />
             </EditCheckbox>
 
-            {editIDCode ? <EditInput>
+            {editHasIDCode? <EditInput>
                   <label htmlFor="edit_len_id_code">Quantidade de caracteres</label>
                   <input
                     type="number"
@@ -383,6 +389,16 @@ const GroupManagers = ({
                     value={editLengthIDCode}
                     min="1"
                     onChange={(e) => handleEditLengthIDCode(e.target.value)}
+                  />
+              </EditInput> : null}
+
+              {editHasIDCode ? <EditInput>
+                  <label htmlFor="edit_id_code">Nome do código de identificação</label>
+                  <input
+                    type="string"
+                    id="edit_id_code"
+                    value={editIDCode}
+                    onChange={(e) => handleEditIDCode(e.target.value)}
                   />
               </EditInput> : null}
           </Modal.Body>

--- a/src/pages/Home/components/GroupManagers/index.js
+++ b/src/pages/Home/components/GroupManagers/index.js
@@ -51,9 +51,6 @@ const GroupManagers = ({
   const [groupManagerEmail, setGroupManagerEmail] = useState("")
   const [groupManagerTwitter, setGroupManagerTwitter] = useState("")
   const [groupManagerGroup, setGroupManagerGroup] = useState("")
-  const [groupManagerHasIdentificationCode, setGroupManagerHasIdentificationCode] = useState(false)
-  const [groupManagerIdentificationCode, setGroupManagerIdentificationCode] = useState('')
-  const [groupManagerLengthIdentificationCode, setGroupManagerLengthIdentificationCode] = useState(1)
   const [groupManagerPassword, setGroupManagerPassword] = useState("")
   const [modalEdit, setModalEdit] = useState(false);
   const [editingGroupManager, setEditingGroupManager] = useState({});
@@ -61,9 +58,6 @@ const GroupManagers = ({
   const [editEmail, setEditEmail] = useState("");
   const [editTwitter, setEditTwitter] = useState("");
   const [editGroup, setEditGroup] = useState("");
-  const [editIDCode, setEditIDCode] = useState(null);
-  const [editHasIDCode, setEditHasIDCode] = useState(false);
-  const [editLengthIDCode, setEditLengthIDCode] = useState(1);
   const [groupManagerShow, setGroupManagerShow] = useState({});
   const [groupManagerLocale, setGroupManagerLocale] = useState(0)
   const [modalShow, setModalShow] = useState(false);
@@ -84,8 +78,6 @@ const GroupManagers = ({
         "password": groupManagerPassword,
         "group_name": groupManagerGroup,
         "twitter": groupManagerTwitter,
-        "require_id": groupManagerHasIdentificationCode? groupManagerIdentificationCode : null,
-        "id_code_length": groupManagerHasIdentificationCode ? groupManagerLengthIdentificationCode : null,
         "app_id": user.app_id,
       }
     }
@@ -106,9 +98,6 @@ const GroupManagers = ({
         setGroupManagerPassword("")
         setGroupManagerEmail("")
         setGroupManagerGroup("")
-        setGroupManagerHasIdentificationCode(false)
-        setGroupManagerIdentificationCode('')
-        setGroupManagerLengthIdentificationCode(0)
         setGroupManagerTwitter("")
         _getAllGroupManagers(token)
       }
@@ -127,8 +116,6 @@ const GroupManagers = ({
         "email": editEmail,
         "group_name": editGroup,
         "twitter": editTwitter,
-        "require_id": editHasIDCode? editIDCode : null,
-        "id_code_length": editHasIDCode ? editLengthIDCode : null,
         "app_id": user.app_id,
       }
     }
@@ -148,9 +135,6 @@ const GroupManagers = ({
     setEditEmail(content.email);
     setEditGroup(content.group_name);
     setEditTwitter(content.twitter);
-    setEditIDCode(content.require_id);
-    setEditHasIDCode(content.require_id !== null)
-    setEditLengthIDCode(content.id_code_length);
     setModalEdit(!modalEdit);
   }
 
@@ -168,18 +152,6 @@ const GroupManagers = ({
 
   const handleEditTwitter = (value) => {
     setEditTwitter(value);
-  }
-
-  const handleEditIDCode = (value) => {
-    setEditIDCode(value);
-  }
-
-  const handleEditHasIDCode = (value) => {
-    setEditHasIDCode(value);
-  }
-
-  const handleEditLengthIDCode = (value) => {
-    setEditLengthIDCode(value);
   }
 
   const loadLocales = async (locale_id=null, locale_name='country') => {
@@ -225,8 +197,6 @@ const GroupManagers = ({
         "email": group_manager.email,
         "group_name": group_manager.group_name,
         "twitter": group_manager.twitter,
-        "require_id": group_manager.require_id,
-        "id_code_length": group_manager.id_code_length,
       })
     })
     if (aux_group_managers.length === 0) {
@@ -313,19 +283,6 @@ const GroupManagers = ({
               disabled
             />
           </EditInput>
-
-          {groupManagerShow.require_id !== null? 
-            <EditInput>
-              <label>Nome do código de identificação</label>
-              <input
-                className="text-dark"
-                type="text"
-                value={groupManagerShow.require_id}
-                disabled
-              />
-            </EditInput>
-          : null
-          }
         </Modal.Body>
 
         <Modal.Footer>
@@ -385,37 +342,6 @@ const GroupManagers = ({
                 onChange={(e) => handleEditTwitter(e.target.value)}
               />
             </EditInput>
-
-            <EditCheckbox>
-              <label htmlFor="edit_has_id_code">Código de Identificação</label>
-              <EditCheckboxInput
-                type="checkbox"
-                id="edit_has_id_code"
-                checked={editHasIDCode}
-                onChange={() => handleEditHasIDCode(!editHasIDCode)}
-              />
-            </EditCheckbox>
-
-            {editHasIDCode? <EditInput>
-                  <label htmlFor="edit_len_id_code">Quantidade de caracteres</label>
-                  <input
-                    type="number"
-                    id="edit_len_id_code"
-                    value={editLengthIDCode}
-                    min="1"
-                    onChange={(e) => handleEditLengthIDCode(e.target.value)}
-                  />
-              </EditInput> : null}
-
-              {editHasIDCode ? <EditInput>
-                  <label htmlFor="edit_id_code">Nome do código de identificação</label>
-                  <input
-                    type="string"
-                    id="edit_id_code"
-                    value={editIDCode}
-                    onChange={(e) => handleEditIDCode(e.target.value)}
-                  />
-              </EditInput> : null}
           </Modal.Body>
           <Modal.Footer>
             <EditButton type="submit">Editar</EditButton>
@@ -540,38 +466,6 @@ const GroupManagers = ({
                     onChange={(e) => setGroupManagerPassword(e.target.value)}
                   />
                 </InputBlock>
-                <CheckboxInputBlock>
-                  <Label htmlFor="has_id_code">Código de Identificação</Label>
-                  <CheckboxInput
-                    type="checkbox"
-                    id="has_id_code"
-                    checked={groupManagerHasIdentificationCode}
-                    onChange={(e) => setGroupManagerHasIdentificationCode(!groupManagerHasIdentificationCode)}
-                  />
-                </CheckboxInputBlock>
-                {groupManagerHasIdentificationCode ?
-                  <InputBlock>
-                    <label htmlFor="len_id_code">Quantidade de caracteres</label>
-                    <Input
-                      type="number"
-                      id="len_id_code"
-                      value={groupManagerLengthIdentificationCode}
-                      min="1"
-                      onChange={(e) => setGroupManagerLengthIdentificationCode(e.target.value)}
-                    />
-                  </InputBlock>
-                  : null}
-                  {groupManagerHasIdentificationCode ?
-                  <InputBlock>
-                    <label htmlFor="id_code">Nome do código de identificação</label>
-                    <Input
-                      type="string"
-                      id="id_code"
-                      value={groupManagerIdentificationCode}
-                      onChange={(e) => setGroupManagerIdentificationCode(e.target.value)}
-                    />
-                  </InputBlock>
-                  : null}
               </Inputs>
               <SubmitButton type="submit">
                 Adicionar

--- a/src/pages/Home/components/GroupManagers/index.js
+++ b/src/pages/Home/components/GroupManagers/index.js
@@ -51,7 +51,8 @@ const GroupManagers = ({
   const [groupManagerEmail, setGroupManagerEmail] = useState("")
   const [groupManagerTwitter, setGroupManagerTwitter] = useState("")
   const [groupManagerGroup, setGroupManagerGroup] = useState("")
-  const [groupManagerIdentificationCode, setGroupManagerIdentificationCode] = useState(false)
+  const [groupManagerHasIdentificationCode, setGroupManagerHasIdentificationCode] = useState(false)
+  const [groupManagerIdentificationCode, setGroupManagerIdentificationCode] = useState('')
   const [groupManagerLengthIdentificationCode, setGroupManagerLengthIdentificationCode] = useState(1)
   const [groupManagerPassword, setGroupManagerPassword] = useState("")
   const [modalEdit, setModalEdit] = useState(false);
@@ -83,8 +84,8 @@ const GroupManagers = ({
         "password": groupManagerPassword,
         "group_name": groupManagerGroup,
         "twitter": groupManagerTwitter,
-        "require_id": groupManagerIdentificationCode,
-        "id_code_length": groupManagerIdentificationCode ? groupManagerLengthIdentificationCode : null,
+        "require_id": groupManagerHasIdentificationCode? groupManagerIdentificationCode : null,
+        "id_code_length": groupManagerHasIdentificationCode ? groupManagerLengthIdentificationCode : null,
         "app_id": user.app_id,
       }
     }
@@ -105,7 +106,8 @@ const GroupManagers = ({
         setGroupManagerPassword("")
         setGroupManagerEmail("")
         setGroupManagerGroup("")
-        setGroupManagerIdentificationCode(false)
+        setGroupManagerHasIdentificationCode(false)
+        setGroupManagerIdentificationCode('')
         setGroupManagerLengthIdentificationCode(0)
         setGroupManagerTwitter("")
         _getAllGroupManagers(token)
@@ -312,15 +314,18 @@ const GroupManagers = ({
             />
           </EditInput>
 
-          <EditInput>
-            <label>Nome do código de identificação</label>
-            <input
-              className="text-dark"
-              type="text"
-              value={groupManagerShow.require_id}
-              disabled
-            />
-          </EditInput>
+          {groupManagerShow.require_id !== null? 
+            <EditInput>
+              <label>Nome do código de identificação</label>
+              <input
+                className="text-dark"
+                type="text"
+                value={groupManagerShow.require_id}
+                disabled
+              />
+            </EditInput>
+          : null
+          }
         </Modal.Body>
 
         <Modal.Footer>
@@ -536,15 +541,15 @@ const GroupManagers = ({
                   />
                 </InputBlock>
                 <CheckboxInputBlock>
-                  <Label htmlFor="id_code">Código de Identificação</Label>
+                  <Label htmlFor="has_id_code">Código de Identificação</Label>
                   <CheckboxInput
                     type="checkbox"
-                    id="id_code"
-                    checked={groupManagerIdentificationCode}
-                    onChange={(e) => setGroupManagerIdentificationCode(!groupManagerIdentificationCode)}
+                    id="has_id_code"
+                    checked={groupManagerHasIdentificationCode}
+                    onChange={(e) => setGroupManagerHasIdentificationCode(!groupManagerHasIdentificationCode)}
                   />
                 </CheckboxInputBlock>
-                {groupManagerIdentificationCode ?
+                {groupManagerHasIdentificationCode ?
                   <InputBlock>
                     <label htmlFor="len_id_code">Quantidade de caracteres</label>
                     <Input
@@ -553,6 +558,17 @@ const GroupManagers = ({
                       value={groupManagerLengthIdentificationCode}
                       min="1"
                       onChange={(e) => setGroupManagerLengthIdentificationCode(e.target.value)}
+                    />
+                  </InputBlock>
+                  : null}
+                  {groupManagerHasIdentificationCode ?
+                  <InputBlock>
+                    <label htmlFor="id_code">Nome do código de identificação</label>
+                    <Input
+                      type="string"
+                      id="id_code"
+                      value={groupManagerIdentificationCode}
+                      onChange={(e) => setGroupManagerIdentificationCode(e.target.value)}
                     />
                   </InputBlock>
                   : null}

--- a/src/pages/Home/components/Profile/index.js
+++ b/src/pages/Home/components/Profile/index.js
@@ -36,7 +36,7 @@ const Profile = ({
     const [appName, setAppName] = useState("");
     const [appTwitter, setAppTwitter] = useState("");
     const [twitter, setTwitter] = useState("");
-    const [requireId, setRequireId] = useState(false);
+    const [requireId, setRequireId] = useState(null);
     const [idCodeLength, setIdCodeLength] = useState(1);
 
     const _editUser = async () => {
@@ -224,13 +224,13 @@ const Profile = ({
                                 <CheckboxInput
                                     type="checkbox"
                                     id="id_code"
-                                    checked={requireId}
-                                    onChange={(e) => setRequireId(!requireId)}
+                                    checked={requireId === null? false : true}
+                                    onChange={(e) => setRequireId(requireId === null? '' : null)}
                                 />
                             </CheckboxInputBlock>
                         }
 
-                        {user.type === "group_manager" && requireId &&
+                        {user.type === "group_manager" && requireId !== null &&
                             <InputBlock>
                                 <label htmlFor="id_code_length">Quantidade de caracteres</label>
                                 <input
@@ -239,6 +239,18 @@ const Profile = ({
                                     value={idCodeLength}
                                     min="1"
                                     onChange={(e) => setIdCodeLength(e.target.value)}
+                                />
+                            </InputBlock>
+                        }
+
+                        {user.type === "group_manager" && requireId !== null &&
+                            <InputBlock>
+                                <label htmlFor="require_id">Nome do código de identificação</label>
+                                <input
+                                    type="string"
+                                    id="require_id"
+                                    value={requireId}
+                                    onChange={(e) => setRequireId(e.target.value)}
                                 />
                             </InputBlock>
                         }

--- a/src/pages/Home/components/Profile/index.js
+++ b/src/pages/Home/components/Profile/index.js
@@ -36,6 +36,7 @@ const Profile = ({
     const [appName, setAppName] = useState("");
     const [appTwitter, setAppTwitter] = useState("");
     const [twitter, setTwitter] = useState("");
+    const [hasRequireID, setHasRequireID] = useState(false);
     const [requireId, setRequireId] = useState(null);
     const [idCodeLength, setIdCodeLength] = useState(1);
 
@@ -51,7 +52,7 @@ const Profile = ({
                 //"email": email,
                 "password": password !== "" ? password : undefined,
                 "twitter": twitter,
-                "require_id": requireId,
+                "require_id": hasRequireID? requireId : null,
                 "id_code_length": idCodeLength,
             }
         }
@@ -94,6 +95,7 @@ const Profile = ({
         setAppId(user.app_id);
         setTwitter(user.twitter);
         setRequireId(user.require_id);
+        setHasRequireID(user.require_id === null? false : true);
         setIdCodeLength(user.id_code_length);
     }
 
@@ -220,17 +222,17 @@ const Profile = ({
 
                         {user.type === "group_manager" &&
                             <CheckboxInputBlock>
-                                <Label htmlFor="id_code">Código de Identificação</Label>
+                                <Label htmlFor="has_id_code">Código de Identificação</Label>
                                 <CheckboxInput
                                     type="checkbox"
-                                    id="id_code"
-                                    checked={requireId === null? false : true}
-                                    onChange={(e) => setRequireId(requireId === null? '' : null)}
+                                    id="has_id_code"
+                                    checked={hasRequireID}
+                                    onChange={(e) => setHasRequireID(!hasRequireID)}
                                 />
                             </CheckboxInputBlock>
                         }
 
-                        {user.type === "group_manager" && requireId !== null &&
+                        {user.type === "group_manager" && hasRequireID &&
                             <InputBlock>
                                 <label htmlFor="id_code_length">Quantidade de caracteres</label>
                                 <input
@@ -243,7 +245,7 @@ const Profile = ({
                             </InputBlock>
                         }
 
-                        {user.type === "group_manager" && requireId !== null &&
+                        {user.type === "group_manager" && hasRequireID &&
                             <InputBlock>
                                 <label htmlFor="require_id">Nome do código de identificação</label>
                                 <input


### PR DESCRIPTION
**Descrição:**
Foi adicionado um campo no perfil do group_manager para alteração do título do código de identificação e retirado a possibilidade dos admins de alterarem ou criarem esse campo, sendo assim esse campo ficou restrito à apenas os group_managers.

 