### PR TITLE
Fixing request that creat group_manager

### DIFF
--- a/src/pages/Home/components/GroupManagers/index.js
+++ b/src/pages/Home/components/GroupManagers/index.js
@@ -79,28 +79,24 @@ const GroupManagers = ({
         "group_name": groupManagerGroup,
         "twitter": groupManagerTwitter,
         "app_id": user.app_id,
+      },
+      "group" : {
+        "description" : groupManagerGroup,
+        "code": "",
+        "children_label" : null,
+        "parent_id" : groupManagerLocale,
+        "group_manager_id" : ""
       }
     }
     const response = await createGroupManager(data, token)
 
     if (response.status === 200) {
-      const group_data = {
-        description: groupManagerGroup,
-        code: "",
-        children_label: null,
-        parent_id: groupManagerLocale,
-        group_manager_id: response.data.group_manager.id,
-      }
-      const response_group = await createGroup(group_data, token)
-
-      if (response_group.status === 201) {
-        setGroupManagerName("")
-        setGroupManagerPassword("")
-        setGroupManagerEmail("")
-        setGroupManagerGroup("")
-        setGroupManagerTwitter("")
-        _getAllGroupManagers(token)
-      }
+      setGroupManagerName("")
+      setGroupManagerPassword("")
+      setGroupManagerEmail("")
+      setGroupManagerGroup("")
+      setGroupManagerTwitter("")
+      _getAllGroupManagers(token)
     }
   }
 


### PR DESCRIPTION
**Descrição**

Foi alterado como as requisições são feitas. Agora para criar um groupManager é necessário mandar junto as informações do group a ser criado. 

Foi criada uma função que cria o grupo 

**Exemplo de request(POST)**
{
  "group_manager" : {
    "name" : group_manager_name,
    "email" : exemplo@email.com,
    "password" : [FILTERED],
    "twitter" : group_manager_twitter,
    ""
  },
  "group" : {
    "description" : group_description,
    "parent_id" : group_parent_id,
  }
}